### PR TITLE
feat(pipeline-youtube-research-podcast): add publish command

### DIFF
--- a/packages/pipeline-youtube-research-podcast/package.json
+++ b/packages/pipeline-youtube-research-podcast/package.json
@@ -25,7 +25,8 @@
     "yt:doctor": "node ./src/cli.js doctor",
     "yt:prep": "node ./src/cli.js prep",
     "yt:latest": "node ./src/cli.js latest",
-    "yt:podcast": "node ./src/cli.js podcast"
+    "yt:podcast": "node ./src/cli.js podcast",
+    "yt:publish": "node ./src/cli.js publish"
   },
   "keywords": [
     "abquanta",

--- a/packages/pipeline-youtube-research-podcast/test/smoke.test.js
+++ b/packages/pipeline-youtube-research-podcast/test/smoke.test.js
@@ -4,6 +4,7 @@ import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
 import { execSync } from 'node:child_process';
+import http from 'node:http';
 
 const CLI = path.resolve(import.meta.dirname, '../src/cli.js');
 const cwd = fs.mkdtempSync(path.join(os.tmpdir(), 'abq-smoke-'));
@@ -39,4 +40,80 @@ test('latest returns a path after prep runs', () => {
   const out = execSync(`node ${CLI} latest`, { cwd, encoding: 'utf8' }).trim();
   assert.ok(out.length > 0, 'Should return a path');
   assert.ok(fs.existsSync(out), 'Returned path should exist');
+});
+
+test('publish without llmProvider fails with clear error', () => {
+  const input = path.join(cwd, 'deep_research_prompt.md');
+  fs.writeFileSync(input, '# Deep Research Brief\n\nContenido de prueba.\n');
+  try {
+    execSync(`node ${CLI} publish --input deep_research_prompt.md`, { cwd, encoding: 'utf8', stdio: 'pipe' });
+    assert.fail('Expected publish to fail without llmProvider');
+  } catch (err) {
+    const stderr = String(err?.stderr || '');
+    assert.match(stderr, /LLM provider not configured/i);
+  }
+});
+
+test('publish fails when input file is missing', () => {
+  try {
+    execSync(`node ${CLI} publish --input missing.md`, { cwd, encoding: 'utf8', stdio: 'pipe' });
+    assert.fail('Expected publish to fail for missing input');
+  } catch (err) {
+    const stderr = String(err?.stderr || '');
+    assert.match(stderr, /Input file not found/i);
+  }
+});
+
+test('publish succeeds with mocked LLM endpoint', async () => {
+  const prompt = path.join(cwd, 'deep_research_prompt.md');
+  fs.writeFileSync(prompt, '# Deep Research Brief\n\nContenido de prueba.\n');
+
+  const sockets = new Set();
+  const server = http.createServer((req, res) => {
+    if (req.method === 'POST' && req.url === '/chat/completions') {
+      let body = '';
+      req.on('data', (c) => { body += c; });
+      req.on('end', () => {
+        res.writeHead(200, { 'content-type': 'application/json', connection: 'close' });
+        res.end(JSON.stringify({ choices: [{ message: { content: 'OK mock output' } }] }));
+      });
+      return;
+    }
+    res.writeHead(404);
+    res.end();
+  });
+  server.on('connection', (socket) => {
+    sockets.add(socket);
+    socket.on('close', () => sockets.delete(socket));
+  });
+
+  await new Promise((resolve) => server.listen(0, '127.0.0.1', resolve));
+  const { port } = server.address();
+  const baseUrl = `http://127.0.0.1:${port}`;
+
+  try {
+    const configPath = path.join(cwd, '.abq-module.json');
+    fs.writeFileSync(configPath, JSON.stringify({
+      llmProvider: 'openai',
+      llmApiKey: 'test-key',
+      baseUrl
+    }, null, 2));
+
+    execSync(`node ${CLI} publish --input deep_research_prompt.md`, { cwd, encoding: 'utf8' });
+
+    const outDir = path.join(cwd, 'output');
+    const runs = fs.readdirSync(outDir).filter(d => d.startsWith('publish-'));
+    assert.ok(runs.length > 0, 'Should have publish output dir');
+    const run = path.join(outDir, runs[0]);
+    assert.ok(fs.existsSync(path.join(run, 'metadata.json')));
+    assert.ok(fs.existsSync(path.join(run, 'podcast_script.md')));
+    assert.ok(fs.existsSync(path.join(run, 'article.md')));
+    assert.ok(fs.existsSync(path.join(run, 'reel_script.md')));
+    assert.ok(fs.existsSync(path.join(run, 'social_posts.md')));
+  } finally {
+    await new Promise((resolve) => server.close(resolve));
+    for (const socket of sockets) {
+      socket.destroy();
+    }
+  }
 });


### PR DESCRIPTION
## Summary
Adds the publish command to generate content packages and updates the podcast script prompt to 2-host dialogue format.

## Type of change

| Type                          | Applies? |
| ----------------------------- | -------- |
| Bug fix                       | ☐        |
| New feature                   | ☑        |
| Breaking change               | ☐        |
| Refactor (no behavior change) | ☐        |
| Performance improvement       | ☐        |
| Documentation                 | ☐        |
| Dependency update             | ☐        |
| CI / tooling                  | ☐        |

## What changed
- Added publish command with LLM calls and metadata output
- Updated podcast_script prompt for HOST_A/HOST_B dialogue format
- Added smoke tests for publish error paths and mock success

## How to test
1. node --test test/smoke.test.js (in packages/pipeline-youtube-research-podcast)

## Evidence
- Smoke tests updated; run status not recorded

## Checklist
- [x] I have added or updated tests
- [ ] I have run full QA (not required for this package)
- [x] This PR contains no unrelated changes
